### PR TITLE
feat: publish a safe playable Soltoons archive

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+build
+node_modules
+.env
+.env.*
+!.env.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM node:18-bullseye-slim AS build
+
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+
+COPY . .
+
+ARG REACT_APP_NETWORK=devnet
+ARG REACT_APP_ENABLE_ONCHAIN=false
+ARG REACT_APP_ENABLE_ADMIN=false
+ARG REACT_APP_RPC
+ARG REACT_APP_GAME_API
+ARG REACT_APP_MIXPANEL
+
+ENV REACT_APP_NETWORK=${REACT_APP_NETWORK}
+ENV REACT_APP_ENABLE_ONCHAIN=${REACT_APP_ENABLE_ONCHAIN}
+ENV REACT_APP_ENABLE_ADMIN=${REACT_APP_ENABLE_ADMIN}
+ENV REACT_APP_RPC=${REACT_APP_RPC}
+ENV REACT_APP_GAME_API=${REACT_APP_GAME_API}
+ENV REACT_APP_MIXPANEL=${REACT_APP_MIXPANEL}
+
+RUN yarn build
+
+FROM nginx:1.27-alpine
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/build /usr/share/nginx/html
+RUN chmod -R a+rX /usr/share/nginx/html
+
+EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-bullseye-slim AS build
+FROM node:24-bookworm-slim AS build
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Demo outcomes are local presentation state. They are not transactions, rewards, 
 
 ## Run locally
 
-Requirements: Node.js 18 and Yarn 1.
+Requirements: Node.js 24 and Yarn 1.
 
 ```bash
 yarn install --frozen-lockfile

--- a/README.md
+++ b/README.md
@@ -1,29 +1,83 @@
-# soltoons
+# Soltoons
 
-## About
+Soltoons is a Solana claw-machine game originally released in 2023. The original product used Switchboard VRF for verifiable outcomes and supported real on-chain rounds. This repository is now being modernized around a wallet-free playable demo so the game and its history remain accessible without asking visitors to connect a wallet or spend funds.
 
-The game is supposed to the feel of an arcade game while the results depend on the players luck. The Switchboard VRF was used to generate Random Numbers verifiably.
-The player can win up to 10x reward on the bet amount. 
+![Soltoons claw machine](public/assets/images/screen.png)
 
+## Current status
 
-### Main game features
+- The wallet-free demo runs locally and does not sign or submit transactions.
+- The historical on-chain mode remains in the codebase but has not yet been revalidated against current wallets, Switchboard, RPC providers, or the deployed program.
+- Historical activity is shown from a timestamped, checked-in Solana mainnet snapshot rather than the retired analytics API.
+- Do not use the on-chain path with real funds until it has completed a fresh security and transaction-flow review.
 
-- Upto 10x Rewards
-- Verifiable Random Numbers
-- VRF is rotated amoung players instead of having 1 each for player (cost reduction)
-- Multiple tokens can be used to play
-- The game flow is built such that funds are only moved to house wallet when result is decided
-- NFT Holders get fee discount
+## Wallet-free demo
 
-# TODO
+1. Open the home page without connecting a wallet.
+2. Press or hold the machine's left/right controls to position the claw. The arrow keys work too.
+3. Select **Drop the claw** or press <kbd>Enter</kbd>.
+4. The original Rive animation plays and returns a clearly labelled demo prize based on the selected position.
+5. Select **Play again** for another round.
 
-- [x] Create UI
-- [x] Add Bonk
-- [x] Add Fee System
-- [ ] Change Image based UI to animation (Rive) UI
-- [x] Add Sounds
-- [x] Add Keyboard Movements
-- [x] Add Mixpanel for analytics
-- [x] Add 24 Hour Stats section
-- [ ] Make a free demo page
-- [x] Make an API to create and assign VRF
+Demo outcomes are local presentation state. They are not transactions, rewards, claims, or evidence of an on-chain result.
+
+## Run locally
+
+Requirements: Node.js 18 and Yarn 1.
+
+```bash
+yarn install --frozen-lockfile
+REACT_APP_NETWORK=devnet yarn start
+```
+
+The application defaults to Solana devnet unless `REACT_APP_NETWORK=mainnet-beta` is set explicitly.
+
+### Docker
+
+```bash
+docker build --build-arg REACT_APP_NETWORK=devnet -t soltoons-demo .
+docker run --rm -p 3000:80 soltoons-demo
+```
+
+Then open `http://localhost:3000`.
+
+## Configuration
+
+All configuration is optional for the wallet-free demo:
+
+| Variable | Purpose |
+|---|---|
+| `REACT_APP_NETWORK` | `devnet` by default; use `mainnet-beta` only for an explicitly reviewed deployment |
+| `REACT_APP_ENABLE_ONCHAIN` | Keeps wallet and transaction controls hidden unless set to `true` |
+| `REACT_APP_ENABLE_ADMIN` | Keeps `/admin` disabled unless both this and on-chain mode are set to `true` |
+| `REACT_APP_RPC` | Solana RPC endpoint; falls back to the public endpoint for the selected network |
+| `REACT_APP_GAME_API` | Required only for the legacy on-chain VRF assignment and result service |
+| `REACT_APP_MIXPANEL` | Optional Mixpanel project token; analytics remain disabled when absent |
+
+Keep deployment values in the deployment platform or a private local environment file. Do not commit credentials.
+
+## Historical on-chain snapshot
+
+The UI reads [`src/data/historicalStats.json`](src/data/historicalStats.json), generated from a read-only Solana mainnet RPC query on 2026-08-14. The bounded query inspected 20,000 program signatures and decoded the latest 500 transactions against the known Soltoons Anchor instruction discriminators.
+
+The snapshot reports raw signatures, successful signatures, current program-owned account types, recognized successful transactions, and distinct interacting fee-payer wallets separately. It does not call signatures “plays,” `UserState` accounts “users,” or wallets “people.” The program address and calculation caveats are included in the file and rendered on the page.
+
+## Historical architecture
+
+- React 18, TypeScript, CRACO, and Tailwind CSS
+- Rive claw-machine animation and audio feedback
+- Solana wallet adapters and Anchor client code
+- Switchboard VRF integration for the historical on-chain game
+- Redux Toolkit state management
+
+## Modernization priorities
+
+- Preserve and polish the wallet-free demo.
+- Replace the deprecated Create React App/CRACO toolchain and reduce the large wallet bundle.
+- Revalidate the on-chain program, Switchboard flow, wallet support, and transaction safety before exposing real-fund controls.
+- Add a public, reproducible refresh script for the checked-in historical snapshot.
+- Add automated interaction tests, CI, and an explicit license decision.
+
+## Provenance
+
+The repository and its commit history are public to preserve the original product work. Historical use is supported by the timestamped on-chain snapshot; its wallet and account counts are deliberately not presented as verified unique people.

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,11 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "homepage": "https://soltoons.vercel.app",
+  "engines": {
+    "node": "24.x"
+  },
   "dependencies": {
     "@craco/craco": "^6.4.3",
     "@emotion/react": "^11.10.6",

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -4,10 +4,13 @@ import { InternalLinks } from './util';
 import Home from './views/Home';
 import Admin from './views/Admin'
 const Router: React.FC = () => {
+  const adminEnabled =
+    process.env.REACT_APP_ENABLE_ONCHAIN === 'true' && process.env.REACT_APP_ENABLE_ADMIN === 'true';
+
   return (
     <Routes>
       <Route path="/" element={<Home />} />
-      <Route path="/admin" element={<Admin />} />
+      {adminEnabled ? <Route path="/admin" element={<Admin />} /> : null}
 
       <Route path="*" element={<Navigate to={InternalLinks.Home} replace={true} />} />
     </Routes>

--- a/src/api/switchboard.ts
+++ b/src/api/switchboard.ts
@@ -13,7 +13,7 @@ export async function loadSwitchboard(
   provider: anchor.AnchorProvider
 ): Promise<SwitchboardProgram> {
   const switchboardProgram = await SwitchboardProgram.load(
-    process.env.REACT_APP_NETWORK === 'devnet' ? 'devnet' : "mainnet-beta",
+    process.env.REACT_APP_NETWORK === 'mainnet-beta' ? 'mainnet-beta' : 'devnet',
     provider.connection,
     ((provider as anchor.AnchorProvider).wallet as AnchorWallet).payer
   );

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -408,7 +408,7 @@ export class User {
         ...vrfContext.publicKeys,
         vrfPayer: payerWrappedSolAccount,
         payer: payerPubkey,
-        nftMint: discount_mint || (process.env.REACT_APP_NETWORK==="devnet"?vrf_mint:backupNft),
+        nftMint: discount_mint || (process.env.REACT_APP_NETWORK === 'mainnet-beta' ? backupNft : vrf_mint),
         nftTokenAccount: nftATA || flip_payer,
         nftMetadataAccount: metadata_account_pda,
         tokenMetadataProgram: METADATA_PROGRAM,

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -15,7 +15,7 @@ const DEFAULT_COMMITMENT = 'confirmed';
 export const defaultRpcForCluster = (cluster: anchor.web3.Cluster | 'localnet') => {
   switch (cluster) {
     case 'mainnet-beta':
-      return 'https://warmhearted-greatest-emerald.solana-mainnet.quiknode.pro/2b6bcf328ed2611d4d293c2aaa027f3139acb0af/';
+      return process.env.REACT_APP_RPC || anchor.web3.clusterApiUrl('mainnet-beta');
     case 'devnet':
       return 'https://api.devnet.solana.com';
     case 'localnet':

--- a/src/components/Analytics/index.tsx
+++ b/src/components/Analytics/index.tsx
@@ -1,92 +1,109 @@
-import axios from 'axios';
-import moment from 'moment';
-import React, { useCallback, useEffect, useState } from 'react'
-import { tokenInfoMap } from '../../data/providers/tokenProvider';
+import React from 'react';
+import historicalStats from '../../data/historicalStats.json';
 
-function Index() {
-    const [events, setEvents] = useState<any>([ ]);
-     const getRecentPlays = useCallback(async () => {
-         try {
-           const to_date=moment().format('YYYY-MM-DD')
-           const from_date= moment().subtract(1, 'day').format('YYYY-MM-DD')
-         const res = await axios.post("https://soltoons-api.vercel.app/api/get-recent-plays", {from_date, to_date})
-        //  const body = await res.data.json();
+const number = new Intl.NumberFormat('en-US');
 
-           if (res.data?.events) {
-            //  console.log(res.data.events, 'EVE')
-           setEvents(res.data.events);
-         } else {
-           setEvents([]);
-         }
-       } catch (error) {
-         console.error(error);
-         setEvents([]);
-       }
-     }, []);
-    
-    useEffect(() => {
-      getRecentPlays()
-    }, [])
+const formatDate = (value: string) =>
+  new Intl.DateTimeFormat('en', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(value));
+
+const cards = [
+  {
+    value: `${number.format(historicalStats.metrics.signaturesInspected)}+`,
+    label: 'signatures inspected',
+    note: 'The bounded query reached its cap.',
+  },
+  {
+    value: number.format(historicalStats.metrics.successfulSignatures),
+    label: 'successful signatures',
+    note: 'Raw chain activity, not a play or user count.',
+  },
+  {
+    value: number.format(historicalStats.metrics.currentAccountTypes.UserState),
+    label: 'current UserState accounts',
+    note: 'Program accounts, not verified unique people.',
+  },
+  {
+    value: number.format(historicalStats.metrics.recognizedSuccessfulTransactionsInSample),
+    label: 'recognized successful actions',
+    note: `From ${historicalStats.methodology.decodedTransactionSample} decoded signatures.`,
+  },
+];
+
+function Analytics() {
+  const instructions = historicalStats.metrics.instructionCountsInSample;
+
   return (
-    <div className="w-full p-6 lg:px-24 ">
-      <div className="text-center text-lg tracking-wider center font-bold pb-4 uppercase">
-        <p className="px-4 py-2 bg-brand_yellow  border-4 border-black">24 Hour Stat ({events.length} Rounds Played)</p>
-      </div>
-      {events.length ? (
-        <div className="h-80vh overflow-y-scroll lg:px-6 small-scrollbar">
-          {events &&
-            events.length &&
-            events
-              .sort((a: any, b: any) => b.time - a.time)
-              .filter((a: any) => a.properties.network !== 'devnet')
-              .map((item: any) => (
-                <div key={item.properties.id + item.time}>
-                  <a
-                    target={'_blank'}
-                    href={`https://explorer.solana.com/tx/${item.properties.id}`}
-                    className={`${
-                      item.properties.multiplier !== 0
-                        ? item.properties.multiplier >= 1
-                          ? ' bg-brand_yellow font-bold'
-                          : ' bg-blue-400 font-light'
-                        : ' bg-gray-400 font-light'
-                    } p-3 mb-3 rounded shadow-xl flex bg-opacity-70 justify-between hover:bg-opacity-100`}
-                    rel="noreferrer"
-                  >
-                    <div className="flex w-10/12">
-                      <p className="w-4/12 text-xs lg:text-lg">
-                        {item.properties.walletId.substring(0, 4)}...
-                        {item.properties.walletId.substring(
-                          item.properties.walletId.length - 4,
-                          item.properties.walletId.length
-                        )}
-                      </p>
-                      <p className="w-4/12  text-xs lg:text-lg pl-2">
-                        Bet {item.properties.bet / Math.pow(10, tokenInfoMap.get(item.properties.mint)?.decimals || 9)}{' '}
-                        {tokenInfoMap.get(item.properties.mint)?.symbol}
-                      </p>
-                      <p className="w-4/12  text-xs lg:text-lg pl-2">
-                        {item.properties.multiplier === 0
-                          ? 'And lost '
-                          : 'And Won ' +
-                            item.properties.change /
-                              Math.pow(10, tokenInfoMap.get(item.properties.mint)?.decimals || 9) +
-                            ' ' +
-                            tokenInfoMap.get(item.properties.mint)?.symbol}{' '}
-                        {/* {tokenInfoMap.get(item.properties.mint)?.symbol} */}
-                      </p>
-                    </div>
-                    <p className="w-2/12 lg:text-2xl font-bold text-right">{item.properties.multiplier}x</p>
-                    {/* <p>{item.properties.id.substring(0, 7)}</p> */}
-                  </a>
-                </div>
-              ))}
+    <section className="w-full px-6 pb-20 lg:px-24" aria-labelledby="historical-activity-title">
+      <div className="mx-auto max-w-6xl">
+        <div className="pb-7 text-center">
+          <h2
+            id="historical-activity-title"
+            className="inline-block border-4 border-black bg-brand_yellow px-5 py-3 text-lg font-extrabold uppercase tracking-wider"
+          >
+            Verified historical on-chain activity
+          </h2>
+          <p className="mx-auto mt-3 max-w-2xl text-sm font-semibold text-white">
+            A checked-in Solana mainnet snapshot generated {formatDate(historicalStats.generatedAt)}. It keeps the
+            playable archive independent from the retired analytics service.
+          </p>
         </div>
-      ) : (
-        <div className="text-white text-center">NONE</div>
-      )}
-    </div>
+
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {cards.map((card) => (
+            <article key={card.label} className="rounded-3xl border-4 border-black bg-brand_yellow p-5 shadow-xl">
+              <p className="text-3xl font-black">{card.value}</p>
+              <h3 className="mt-1 text-sm font-extrabold uppercase">{card.label}</h3>
+              <p className="mt-3 text-xs font-semibold leading-relaxed">{card.note}</p>
+            </article>
+          ))}
+        </div>
+
+        <div className="mt-5 grid gap-5 rounded-3xl border-4 border-black bg-black/80 p-6 text-white md:grid-cols-2">
+          <div>
+            <h3 className="text-sm font-extrabold uppercase text-brand_yellow">Decoded sample</h3>
+            <p className="mt-2 text-sm leading-relaxed">
+              {number.format(historicalStats.metrics.interactingFeePayersInSample)} distinct fee-payer wallets made
+              recognized successful calls in the decoded sample. That is evidence of interacting wallets—not a claim
+              about unique people.
+            </p>
+            <p className="mt-3 text-xs leading-relaxed text-gray-300">
+              {instructions.userBet} bets · {instructions.userSettle} settlements · {instructions.collectReward}{' '}
+              reward collections · {instructions.userInit} user initializations
+            </p>
+          </div>
+          <div>
+            <h3 className="text-sm font-extrabold uppercase text-brand_yellow">Observed history</h3>
+            <p className="mt-2 text-sm leading-relaxed">
+              The inspected range begins {formatDate(historicalStats.observedActivity.oldestSignatureInRange)}. The most
+              recent recognized successful Soltoons action in this snapshot is{' '}
+              {formatDate(historicalStats.observedActivity.newestRecognizedSuccessfulActivity)}.
+            </p>
+            <a
+              className="mt-3 inline-block text-xs font-extrabold uppercase text-brand_yellow underline decoration-2 underline-offset-4"
+              href={historicalStats.explorerUrl}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Inspect the program on Solana Explorer
+            </a>
+          </div>
+        </div>
+
+        <details className="mt-4 rounded-2xl border-2 border-white/30 bg-black/60 p-4 text-xs text-gray-200">
+          <summary className="cursor-pointer font-extrabold uppercase text-white">How these numbers were derived</summary>
+          <p className="mt-3 leading-relaxed">{historicalStats.methodology.note}</p>
+          <p className="mt-2 break-all leading-relaxed">
+            Program: {historicalStats.programId} · Source: {historicalStats.source}
+          </p>
+        </details>
+      </div>
+    </section>
   );
 }
 
-export default Index
+export default Analytics;

--- a/src/components/GameRive/index.tsx
+++ b/src/components/GameRive/index.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import { hooks, Store } from '../../data';
+import { useState, useEffect, useCallback } from 'react';
+import { Store } from '../../data';
 import { useSelector } from 'react-redux';
 import { useRive, useStateMachineInput } from '@rive-app/react-canvas';
 import useSound from 'use-sound';
@@ -17,7 +17,7 @@ const plushies = {
 };
 
 //@ts-ignore
-function Game({ amount, step, setStep, handleModalOpen, sound }) {
+function Game({ step, setStep, handleModalOpen, sound, demoResult, isDemo, demoRunning, onDemoPlay, x, setX }) {
   //sound
   const [playWin, stopWin] = useSound('/assets/audio/win.mp3', {
     volume: sound ? 1 : 0,
@@ -43,14 +43,13 @@ function Game({ amount, step, setStep, handleModalOpen, sound }) {
   const moveLeftInput = useStateMachineInput(rive, STATE_MACHINE_NAME, 'moveLeft'); //boolean
   const resultInput = useStateMachineInput(rive, STATE_MACHINE_NAME, 'Result'); //number 0-7
   const posInput = useStateMachineInput(rive, STATE_MACHINE_NAME, 'pos'); //number 0/100
-  //api
-  const api = hooks.useApi();
-  const [x, setX] = useState(50);
   const [leftHold, setLeftHold] = useState(false);
   const [rightHold, setRightHold] = useState(false);
 
   //@ts-ignore
-  const result = useSelector((store: Store) => store.gameState.result);
+  const chainResult = useSelector((store: Store) => store.gameState.result);
+  const result = demoResult ?? chainResult;
+  const canMove = step === 0 && result.status !== 'waiting' && result.status !== 'success' && !demoRunning;
 
   useEffect(() => {
     if (result.status === 'waiting') {
@@ -89,71 +88,40 @@ function Game({ amount, step, setStep, handleModalOpen, sound }) {
   }, [playNeutral, playWin, result.multiplier, result?.userWon, setStep, step]);
 
   useEffect(() => {
-    if (leftHold || rightHold) {
-      let newX = x;
-      if (leftHold && step < 3) {
-        newX = x - 0.1;
-        if (newX >= 0 && newX <= 100) {
-          if (moveLeftInput) moveLeftInput.value = true; //move left button in rive
-          playSlide();
-        } else {
-          stopSlide.stop();
-        }
-      } else if (rightHold && !step) {
-        newX = x + 0.1;
-        if (newX >= 0 && newX <= 100) {
-          playSlide();
-          if (moveRightInput) moveRightInput.value = true; //move right button in rive
-        } else {
-          stopSlide.stop();
-        }
-      }
+    if (canMove && (leftHold || rightHold)) {
+      if (moveLeftInput) moveLeftInput.value = leftHold;
+      if (moveRightInput) moveRightInput.value = rightHold;
+      playSlide();
     } else {
       if (moveLeftInput) moveLeftInput.value = false; //disable move button in rive
       if (moveRightInput) moveRightInput.value = false; // disable move button in rive
       stopSlide.stop();
     }
-  }, [leftHold, rightHold, x, step, moveLeftInput, playSlide, stopSlide, moveRightInput]);
+  }, [canMove, leftHold, moveLeftInput, moveRightInput, playSlide, rightHold, stopSlide]);
 
   useEffect(() => {
-    let interval: any;
-    let newX = x - 0.1;
-    if (leftHold && posInput && posInput?.value === 0)
-      interval = setInterval(() => {
-        if (newX >= 0 && newX <= 100) {
-          setX(newX);
-          if (xAxisInput) xAxisInput.value = newX;
-          newX = newX - 0.1;
-        }
-      }, 1);
+    if (!canMove || (!leftHold && !rightHold)) return;
 
-    return () => {
-      clearInterval(interval);
-    };
-  }, [leftHold, posInput, step, x, xAxisInput]);
+    const direction = leftHold ? -1 : 1;
+    const interval = window.setInterval(() => {
+      setX((currentX: number) => Math.max(0, Math.min(100, currentX + direction)));
+    }, 20);
 
-  useEffect(() => {
-    let interval: any;
-    let newX = x + 0.1;
-    if (rightHold && posInput && posInput?.value === 0)
-      interval = setInterval(() => {
-        if (newX >= 0 && newX <= 100) {
-          setX(newX);
-          if (xAxisInput) xAxisInput.value = newX;
-          newX = newX + 0.1;
-        }
-      }, 1);
+    return () => window.clearInterval(interval);
+  }, [canMove, leftHold, rightHold, setX]);
 
-    return () => {
-      clearInterval(interval);
-    };
-  }, [posInput, rightHold, step, x, xAxisInput]);
+  const nudgeClaw = useCallback(
+    (direction: -1 | 1) => {
+      if (!canMove) return;
+      setX((currentX: number) => Math.max(0, Math.min(100, currentX + direction * 12.5)));
+    },
+    [canMove, setX]
+  );
 
   //rive movement after getting collecting rewards
 
   useEffect(() => {
     if (result.status === 'claimed') {
-      console.log('claimed');
       setStep(0);
       if (posInput) posInput.value = 0; //set pos 0
       if (resultInput) resultInput.value = 0; //set reward 0
@@ -161,28 +129,33 @@ function Game({ amount, step, setStep, handleModalOpen, sound }) {
     }
   }, [posInput, refreshInput, result, resultInput, setStep]);
 
-  function handleKeyDown(e: any) {
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (e.code === 'Enter') {
-      api.handleCommand(`user play 1 ${amount}`);
+      if (isDemo) onDemoPlay();
     }
     if (e.code === 'ArrowRight') {
-      setRightHold(true);
+      if (canMove) setRightHold(true);
     }
     if (e.code === 'ArrowLeft') {
-      setLeftHold(true);
+      if (canMove) setLeftHold(true);
     }
-  }
-  function handleKeyUp(e: any) {
+  }, [canMove, isDemo, onDemoPlay]);
+
+  const handleKeyUp = useCallback(() => {
     if (moveLeftInput?.value) moveLeftInput.value = false;
     if (moveRightInput?.value) moveRightInput.value = false;
     setLeftHold(false);
     setRightHold(false);
-  }
+  }, [moveLeftInput, moveRightInput]);
 
   useEffect(() => {
     document.addEventListener('keydown', handleKeyDown);
     document.addEventListener('keyup', handleKeyUp);
-  }, []);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('keyup', handleKeyUp);
+    };
+  }, [handleKeyDown, handleKeyUp]);
 
   useEffect(() => {
     if (xAxisInput) {
@@ -203,18 +176,32 @@ function Game({ amount, step, setStep, handleModalOpen, sound }) {
             result?.userWon ? ' cursor-pointer  glow ' : ''
           } w-[15%] lg:w-[10%] xl:w-[13%] 2xl:w-[20%] absolute z-[1] bottom-[5%] left-[17%] md:left-[17%] lg:left-[17%] xl:left-[17%] 2xl:left-[15%]`}
         ></div>
-        <div
-          onMouseDown={() => setLeftHold(true)}
-          onMouseUp={() => setLeftHold(false)}
-          onTouchStart={() => !rightHold && setLeftHold(!leftHold)}
-          className="h-[5%] w-[7%] cursor-pointer lg:w-[5%] absolute z-[1] bottom-[28%] md:bottom-[27%] left-[40%] "
-        ></div>
-        <div
-          onMouseDown={() => setRightHold(true)}
-          onMouseUp={() => setRightHold(false)}
-          onTouchStart={() => !leftHold && setRightHold(!rightHold)}
-          className="h-[5%] w-[7%] cursor-pointer lg:w-[5%] absolute z-[1] bottom-[28%] md:bottom-[27%] left-[55%]"
-        ></div>
+        <button
+          type="button"
+          aria-label="Move claw left"
+          aria-pressed={leftHold}
+          disabled={!canMove}
+          onPointerDown={() => !rightHold && setLeftHold(true)}
+          onPointerUp={() => setLeftHold(false)}
+          onPointerCancel={() => setLeftHold(false)}
+          onPointerLeave={() => setLeftHold(false)}
+          onBlur={() => setLeftHold(false)}
+          onClick={() => nudgeClaw(-1)}
+          className="absolute bottom-[28%] left-[40%] z-[1] h-[5%] w-[7%] cursor-pointer touch-none rounded-full border-0 bg-transparent focus:outline-none focus-visible:ring-4 focus-visible:ring-white disabled:cursor-not-allowed md:bottom-[27%] lg:w-[5%]"
+        />
+        <button
+          type="button"
+          aria-label="Move claw right"
+          aria-pressed={rightHold}
+          disabled={!canMove}
+          onPointerDown={() => !leftHold && setRightHold(true)}
+          onPointerUp={() => setRightHold(false)}
+          onPointerCancel={() => setRightHold(false)}
+          onPointerLeave={() => setRightHold(false)}
+          onBlur={() => setRightHold(false)}
+          onClick={() => nudgeClaw(1)}
+          className="absolute bottom-[28%] left-[55%] z-[1] h-[5%] w-[7%] cursor-pointer touch-none rounded-full border-0 bg-transparent focus:outline-none focus-visible:ring-4 focus-visible:ring-white disabled:cursor-not-allowed md:bottom-[27%] lg:w-[5%]"
+        />
       </div>
     </div>
   );

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -39,8 +39,37 @@ function LinearProgressWithLabel(props: LinearProgressProps & { value: number })
     </Box>
   );
 }
-//@ts-ignore
-function Sidebar({ amount, setAmount, step, setStep, handleModalClose, openModal, sound, setSound }) {
+type SidebarProps = {
+  amount: number;
+  setAmount: React.Dispatch<React.SetStateAction<number>>;
+  step: number;
+  setStep: React.Dispatch<React.SetStateAction<number>>;
+  handleModalClose: () => void;
+  openModal: boolean;
+  sound: boolean;
+  setSound: React.Dispatch<React.SetStateAction<boolean>>;
+  demoResult: { status: string } | null;
+  demoRunning: boolean;
+  demoMessage: string;
+  onDemoPlay: () => void;
+  onchainEnabled: boolean;
+};
+
+function Sidebar({
+  amount,
+  setAmount,
+  step,
+  setStep,
+  handleModalClose,
+  openModal,
+  sound,
+  setSound,
+  demoResult,
+  demoRunning,
+  demoMessage,
+  onDemoPlay,
+  onchainEnabled,
+}: SidebarProps) {
   const wallet = useWallet();
   const { connection } = useConnection();
   const [playLoading, stopLoading] = useSound('/assets/audio/loading.mp3', {
@@ -342,7 +371,7 @@ function Sidebar({ amount, setAmount, step, setStep, handleModalClose, openModal
       )}
       <div className="part1  md:h-[20%]  center w-full">
         <div className="w-full">
-          {wallet?.connected && (
+          {onchainEnabled && wallet?.connected && (
             <div className="tokenSelector mb-1">
               <Select
                 readOnly
@@ -371,9 +400,15 @@ function Sidebar({ amount, setAmount, step, setStep, handleModalClose, openModal
               </Select>
             </div>
           )}
-          <div className="bg-brand_yellow walletMultiButton">
-            <WalletMultiButton color="inherit" className={'walletButton'} />
-          </div>
+          {onchainEnabled ? (
+            <div className="bg-brand_yellow walletMultiButton">
+              <WalletMultiButton color="inherit" className={'walletButton'} />
+            </div>
+          ) : (
+            <div className="rounded-3xl border-4 border-black bg-brand_yellow px-4 py-3 text-center text-xs font-extrabold">
+              PLAYABLE ARCHIVE · ON-CHAIN MODE OFF
+            </div>
+          )}
         </div>
       </div>
       {wallet?.connected && (
@@ -431,6 +466,11 @@ function Sidebar({ amount, setAmount, step, setStep, handleModalClose, openModal
                 escrow={tokenEscrow}
                 discountNft={discountNft}
                 houseVaultBal={houseVaultBal}
+                isDemo={!onchainEnabled || !wallet.connected}
+                demoResult={demoResult}
+                demoRunning={demoRunning}
+                demoMessage={demoMessage}
+                onDemoPlay={onDemoPlay}
               />
             </div>
           )}
@@ -661,7 +701,36 @@ const Play = ({
   tokenInfo,
   escrow,
   discountNft,
-  houseVaultBal}: any) => {
+  houseVaultBal,
+  isDemo,
+  demoResult,
+  demoRunning,
+  demoMessage,
+  onDemoPlay,
+}: any) => {
+  if (isDemo) {
+    return (
+      <div className="flex h-full w-full flex-col items-center justify-center px-3">
+        <p className="w-full border-b-2 pb-2 text-center text-base font-extrabold">FREE DEMO</p>
+        <p className="py-3 text-xs font-semibold">Use the machine controls to choose a position, then drop the claw.</p>
+        <button
+          id="demo-play-button"
+          type="button"
+          disabled={demoRunning}
+          onClick={onDemoPlay}
+          className={`w-10/12 rounded-3xl border-4 border-black p-2 text-xs font-extrabold ${
+            demoRunning ? 'cursor-wait bg-gray-300' : 'bg-yellow-300 hover:bg-yellow-500'
+          }`}
+        >
+          {demoRunning ? 'CLAW IN MOTION...' : demoResult?.status === 'success' ? 'PLAY AGAIN' : 'DROP THE CLAW'}
+        </button>
+        <p aria-live="polite" className="min-h-[2.5rem] pt-3 text-center text-xs">
+          {demoMessage}
+        </p>
+      </div>
+    );
+  }
+
   const isWsol = tokenInfo.address === wsol;
   const token = tokenInfo;
   //TODO: loading when play button pressed
@@ -831,5 +900,3 @@ function convertToShortForm(n: number): string {
   }
   return num.toFixed(1) + suffix;
 }
-
-

--- a/src/data/historicalStats.json
+++ b/src/data/historicalStats.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-14T14:30:08Z",
+  "network": "mainnet-beta",
+  "programId": "soLDMzSg7VgDp6SjNXoySM3iko5sFcnwXzKZcv8r8yL",
+  "explorerUrl": "https://explorer.solana.com/address/soLDMzSg7VgDp6SjNXoySM3iko5sFcnwXzKZcv8r8yL",
+  "source": "Solana mainnet RPC queried through Helius with helius_onchain_stats.mjs",
+  "methodology": {
+    "signatureLimit": 20000,
+    "signatureLimitReached": true,
+    "decodedTransactionSample": 500,
+    "knownInstructions": [
+      "collectReward",
+      "createEscrow",
+      "drain",
+      "houseInit",
+      "userAirdrop",
+      "userBet",
+      "userInit",
+      "userSettle"
+    ],
+    "note": "Raw signatures include failed probes and unrelated calls. Recognized activity counts only successful transactions containing a known Soltoons Anchor instruction. Wallets are distinct fee payers in the decoded sample, not verified unique people."
+  },
+  "observedActivity": {
+    "oldestSignatureInRange": "2023-01-27T20:21:41.000Z",
+    "newestSignature": "2026-07-28T13:44:58.000Z",
+    "newestRecognizedSuccessfulActivity": "2025-04-17T01:14:18.000Z"
+  },
+  "metrics": {
+    "signaturesInspected": 20000,
+    "successfulSignatures": 19894,
+    "failedSignatures": 106,
+    "currentProgramAccounts": 132,
+    "currentAccountTypes": {
+      "UserState": 112,
+      "HouseState": 2,
+      "Unknown": 18
+    },
+    "recognizedSuccessfulTransactionsInSample": 35,
+    "recognizedInstructionsInSample": 36,
+    "interactingFeePayersInSample": 12,
+    "instructionCountsInSample": {
+      "userBet": 12,
+      "userSettle": 10,
+      "collectReward": 9,
+      "userInit": 5
+    }
+  }
+}

--- a/src/data/providers/ApiProvider.tsx
+++ b/src/data/providers/ApiProvider.tsx
@@ -140,7 +140,8 @@ class ApiState implements PrivateApiInterface {
     // @TODO make rpc connection configurable.
 
     //@ts-ignore
-    return process.env.REACT_APP_NETWORK === 'devnet' ? 'https://api.devnet.solana.com' : process.env.REACT_APP_RPC;
+    const network = process.env.REACT_APP_NETWORK === 'mainnet-beta' ? 'mainnet-beta' : 'devnet';
+    return process.env.REACT_APP_RPC || anchor.web3.clusterApiUrl(network);
   }
 
   /**
@@ -648,7 +649,7 @@ class ApiState implements PrivateApiInterface {
     }
     console.info('VRF used is: ', vrf.id);
     localStorage.setItem("vrf",vrf.id)
-    const DEFAULT_STATE_BUMP = process.env.REACT_APP_NETWORK === 'devnet' ? 255 : 249;
+    const DEFAULT_STATE_BUMP = process.env.REACT_APP_NETWORK === 'mainnet-beta' ? 249 : 255;
     const request = await user
       .placeBetReq(
         {
@@ -662,9 +663,9 @@ class ApiState implements PrivateApiInterface {
         new PublicKey(
           vrf
             ? vrf.id
-            : process.env.REACT_APP_NETWORK === 'devnet'
-            ? '4V4hFcswusaQ9tC5CJekc5YqraNQw4QxBDiSbPLDF4k5'
-            : '8fGps8aCBrkNguLHt9SKHwNvtg7UeTH6MvVQ5y8dDySs'
+            : process.env.REACT_APP_NETWORK === 'mainnet-beta'
+            ? '8fGps8aCBrkNguLHt9SKHwNvtg7UeTH6MvVQ5y8dDySs'
+            : '4V4hFcswusaQ9tC5CJekc5YqraNQw4QxBDiSbPLDF4k5'
         ),
         vrf?.permission_bump || 255,
         vrf?.state_bump || DEFAULT_STATE_BUMP,
@@ -962,8 +963,9 @@ class ApiState implements PrivateApiInterface {
             userWon: event.userWon,
           })
         );
-        if (signature) {
-          await axios.post('https://soltoons-api.vercel.app/api/add-result', {
+        const gameApi = process.env.REACT_APP_GAME_API;
+        if (signature && gameApi) {
+          await axios.post(`${gameApi}/api/add-result`, {
             walletId: this.wallet.publicKey.toBase58(),
             id: signature,
             vrf: localStorage.getItem("vrf")||"",

--- a/src/data/providers/WalletProvider.tsx
+++ b/src/data/providers/WalletProvider.tsx
@@ -11,16 +11,12 @@ import {
 } from '@solana/wallet-adapter-wallets';
 
 import toast from 'react-hot-toast';
-const extendedClusterApiUrl = () => {
-  return (
-    process.env.REACT_APP_RPC ||
-    'https://warmhearted-greatest-emerald.solana-mainnet.quiknode.pro/2b6bcf328ed2611d4d293c2aaa027f3139acb0af/'
-  );
-};
+import { clusterApiUrl } from '@solana/web3.js';
 
 const Wallet: FC = ({ children }:any) => {
-  const network = process.env.REACT_APP_NETWORK==="devnet"?"devnet":"mainnet-beta";
-  const endpoint = useMemo(() => extendedClusterApiUrl(), []);
+  const onchainEnabled = process.env.REACT_APP_ENABLE_ONCHAIN === 'true';
+  const network = process.env.REACT_APP_NETWORK === 'mainnet-beta' ? 'mainnet-beta' : 'devnet';
+  const endpoint = useMemo(() => process.env.REACT_APP_RPC || clusterApiUrl(network), [network]);
 
   // @solana/wallet-adapter-wallets imports all the adapters but supports tree shaking --
   // Only the wallets you want to support will be compiled into your application
@@ -45,7 +41,7 @@ const Wallet: FC = ({ children }:any) => {
 
   return (
     <ConnectionProvider endpoint={endpoint}>
-      <WalletProvider wallets={wallets} onError={onError} autoConnect>
+      <WalletProvider wallets={wallets} onError={onError} autoConnect={onchainEnabled}>
         <WalletDialogProvider featuredWallets={5}>{children}</WalletDialogProvider>
       </WalletProvider>
     </ConnectionProvider>

--- a/src/data/providers/utils.ts
+++ b/src/data/providers/utils.ts
@@ -1,18 +1,17 @@
 import axios from 'axios';
 
-export const getVRF = async(user:string) => {
-    let data = null;
-    await axios.post('https://soltoons-api.vercel.app/api/assign-vrf', {
-        user,
-        network: process.env.REACT_APP_NETWORK==="devnet"?"devnet":"mainnet"
-    }).then(res => {
-        if (res.data.vrf) {
-            data = res.data.vrf;
-        }
-    }).catch(async(err) => {
-        return null;
+export const getVRF = async (user: string) => {
+  const gameApi = process.env.REACT_APP_GAME_API;
+  if (!gameApi) return null;
+
+  try {
+    const response = await axios.post(`${gameApi}/api/assign-vrf`, {
+      user,
+      network: process.env.REACT_APP_NETWORK === 'mainnet-beta' ? 'mainnet' : 'devnet',
     });
 
-    return data
-   
-}
+    return response.data.vrf ?? null;
+  } catch {
+    return null;
+  }
+};

--- a/src/util/Mixpanel.ts
+++ b/src/util/Mixpanel.ts
@@ -1,26 +1,26 @@
 import mixpanel from 'mixpanel-browser';
 
-const PROD_TOKEN = process.env.REACT_APP_MIXPANEL || "5fa23edbf619e78b0fc68a47f493167d";
-mixpanel.init(PROD_TOKEN);
-mixpanel.set_config({
-    ip: true,
-    ignore_dnt: true,
-});
-let actions = {
+const PROD_TOKEN = process.env.REACT_APP_MIXPANEL;
+const enabled = Boolean(PROD_TOKEN);
+
+if (PROD_TOKEN) {
+    mixpanel.init(PROD_TOKEN);
+    mixpanel.set_config({ ip: false });
+}
+
+export const Mixpanel = {
     identify: (id: any) => {
-        mixpanel.identify(id);
+        if (enabled) mixpanel.identify(id);
     },
     alias: (id: any) => {
-        mixpanel.alias(id);
+        if (enabled) mixpanel.alias(id);
     },
     track: (name: any, props: any) => {
-        mixpanel.track(name, props);
+        if (enabled) mixpanel.track(name, props);
     },
     people: {
         set: (props: any) => {
-            mixpanel.people.set(props);
+            if (enabled) mixpanel.people.set(props);
         },
     },
 };
-
-export let Mixpanel = actions;

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -1,13 +1,37 @@
 import Sidebar from '../../components/Sidebar';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import LoadingScreen from "../../components/LoadingScreen"
 import Analytics from '../../components/Analytics';
 import GameRive from '../../components/GameRive';
 
 import Countdown from 'react-countdown';
 import { FaDiscord, FaTwitter } from 'react-icons/fa';
+import { useWallet } from '@solana/wallet-adapter-react';
+
+const onchainEnabled = process.env.REACT_APP_ENABLE_ONCHAIN === 'true';
+
+const demoPrizes = [
+  { multiplier: '0.3', label: 'Banana sticker' },
+  { multiplier: '0.5', label: 'Toobs' },
+  { multiplier: '0.8', label: 'Arcade cap' },
+  { multiplier: '1.0', label: 'Skull plushie' },
+  { multiplier: '2.0', label: 'Golden banana' },
+  { multiplier: '5.0', label: 'Golden cap' },
+  { multiplier: '8.0', label: 'Golden toobs' },
+  { multiplier: '10.0', label: 'Golden snake' },
+];
+
+type DemoResult = {
+  status: 'claimed' | 'waiting' | 'success';
+  userWon?: boolean;
+  multiplier?: string;
+  label?: string;
+};
+
 function Index() {
-  const [amount, setAmount] = useState('1');
+  const { connected } = useWallet();
+  const demoMode = !onchainEnabled || !connected;
+  const [amount, setAmount] = useState(1);
   const [step, setStep] = useState(0);
 
   const [splash, setSplash] = useState(true);
@@ -33,10 +57,68 @@ function Index() {
   const handleModalOpen = () => setOpenModal(true);
   const handleModalClose = () => setOpenModal(false);
   const [sound, setSound] = useState(true);
+  const [demoResult, setDemoResult] = useState<DemoResult | null>(null);
+  const [demoRunning, setDemoRunning] = useState(false);
+  const [demoMessage, setDemoMessage] = useState('Move the claw, then drop it. No wallet or funds required.');
+  const [clawPosition, setClawPosition] = useState(50);
+  const demoTimers = useRef<number[]>([]);
 
   useEffect(() => {
     setSound(localStorage.getItem('soltoons-sound') === 'true');
   }, []);
+
+  useEffect(
+    () => () => {
+      demoTimers.current.forEach((timer) => window.clearTimeout(timer));
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!connected || !onchainEnabled) return;
+
+    demoTimers.current.forEach((timer) => window.clearTimeout(timer));
+    demoTimers.current = [];
+    setDemoResult(null);
+    setDemoRunning(false);
+    setDemoMessage('Move the claw, then drop it. No wallet or funds required.');
+  }, [connected]);
+
+  const playDemo = useCallback(() => {
+    if (demoRunning) return;
+
+    demoTimers.current.forEach((timer) => window.clearTimeout(timer));
+    demoTimers.current = [];
+
+    const prizeIndex = Math.min(
+      demoPrizes.length - 1,
+      Math.max(0, Math.round((clawPosition / 100) * (demoPrizes.length - 1)))
+    );
+    const prize = demoPrizes[prizeIndex];
+
+    setDemoRunning(true);
+    setDemoMessage('The claw is moving...');
+    setStep(0);
+    setDemoResult({ status: 'claimed' });
+
+    demoTimers.current.push(
+      window.setTimeout(() => setDemoResult({ status: 'waiting' }), 150),
+      window.setTimeout(
+        () =>
+          setDemoResult({
+            status: 'success',
+            userWon: true,
+            multiplier: prize.multiplier,
+            label: prize.label,
+          }),
+        1100
+      ),
+      window.setTimeout(() => {
+        setDemoMessage(`You grabbed ${prize.label} — ${prize.multiplier}x demo prize.`);
+        setDemoRunning(false);
+      }, 3300)
+    );
+  }, [clawPosition, demoRunning]);
 
   // Renderer callback with condition
   const renderer = ({ days, hours, minutes, seconds, completed }:any) => {
@@ -78,7 +160,18 @@ function Index() {
         {splash ? <LoadingScreen style={style} /> : <></>}
         <div className=" flex  relative 2xl:justify-center items-center">
           <div className="2xl:max-w-[1920px] 2xl:max-h-[1080px] w-full  h-screen items-center flex flex-wrap bg-yellow-00 min-h-[120vh] lg:max-h-screen  md:min-h-[100vh]">
-            <GameRive amount={amount} step={step} setStep={setStep} handleModalOpen={handleModalOpen} sound={sound} />
+            <GameRive
+              step={step}
+              setStep={setStep}
+              handleModalOpen={handleModalOpen}
+              sound={sound}
+              demoResult={demoMode ? demoResult : null}
+              isDemo={demoMode}
+              demoRunning={demoRunning}
+              onDemoPlay={playDemo}
+              x={clawPosition}
+              setX={setClawPosition}
+            />
             <Sidebar
               amount={amount}
               setAmount={setAmount}
@@ -88,6 +181,11 @@ function Index() {
               openModal={openModal}
               sound={sound}
               setSound={setSound}
+              demoResult={demoResult}
+              demoRunning={demoRunning}
+              demoMessage={demoMessage}
+              onDemoPlay={playDemo}
+              onchainEnabled={onchainEnabled}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary

- add a wallet-free claw-machine demo where the physical left/right controls determine the local prize
- keep wallet transactions and `/admin` disabled by default
- replace the retired analytics API with a timestamped, checked-in Solana mainnet snapshot
- remove hardcoded RPC, game-service, and Mixpanel values from current source
- add a reproducible Node 18/Nginx production image and deployment documentation

## Historical evidence boundary

The 2026-08-14 snapshot inspected 20,000 program signatures (the configured cap) and decoded the latest 500. It reports signatures, program accounts, recognized successful actions, and interacting fee-payer wallets separately. It does not present these as plays, users, or unique people.

## Verification

- `docker build -t repo-audit-soltoons:local .`
- production image: `83631baa149019adc92e7c1a37d9eafbb1af253755cac7c3a832af79444eb797`
- clean browser session: three right-control presses produced `Golden toobs — 8.0x`
- all four historical evidence cards rendered with expected values
- `/admin` redirected to `/`
- 390 x 844 check had no horizontal overflow
- no captured production page or console errors

## Safety and remaining debt

- no environment file is added or changed
- keep `REACT_APP_ENABLE_ONCHAIN` and `REACT_APP_ENABLE_ADMIN` unset or false for preview and production
- real-money mode remains unverified
- full TypeScript checking still fails in pre-existing generated/on-chain code and an unused walletkit import
- dependency modernization and an explicit license decision remain follow-up work

This is intentionally a draft for preview deployment and review before any production promotion.